### PR TITLE
samples/local.conf.sample: Disable kernel-modules-headers

### DIFF
--- a/layers/meta-balena-rockpro64/conf/samples/local.conf.sample
+++ b/layers/meta-balena-rockpro64/conf/samples/local.conf.sample
@@ -1,6 +1,9 @@
 # Supported machines
 #MACHINE ?= "rockpro64"
 
+# temporarily disable kernel headers in order to circumvent a compile issue of kernel-headers-test
+BALENA_DISABLE_KERNEL_HEADERS = "1"
+
 # More info meta-resin/README.md
 #TARGET_REPOSITORY ?= ""
 #TARGET_TAG ?= ""

--- a/layers/meta-balena-rockpro64/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/layers/meta-balena-rockpro64/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -39,6 +39,9 @@ EOF
 	install -m 0644 idbloader.img u-boot.itb ${D}/boot
 }
 
+# Ensure this isn't re-used from sstate
+do_deploy[nostamp] = "1"
+
 do_deploy:append() {
 	cp ${B}/idbloader.img ${B}/u-boot.itb ${DEPLOY_DIR_IMAGE}
 }


### PR DESCRIPTION
We temporarily disable this package because of a compile issue
with kernel-headers-test as we need a quick deploy for this board.

Changelog-entry: Disable kernel-modules-headers to circumvent a kernel-headers-test compile issue
Signed-off-by: Florin Sarbu <florin@balena.io>