### PR TITLE
linux-rockchip: enable RNG

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,9 +7,6 @@
 [submodule "layers/meta-rockchip"]
 	path = layers/meta-rockchip
 	url = https://github.com/JeffyCN/meta-rockchip.git
-[submodule "layers/meta-rust"]
-	path = layers/meta-rust
-	url = https://github.com/meta-rust/meta-rust.git
 [submodule "layers/meta-balena"]
 	path = layers/meta-balena
 	url = https://github.com/balena-os/meta-balena.git

--- a/layers/meta-balena-rockpro64/conf/machine/rockpro64.conf
+++ b/layers/meta-balena-rockpro64/conf/machine/rockpro64.conf
@@ -28,3 +28,5 @@ UBOOT_MACHINE = "rockpro64-rk3399_defconfig"
 MACHINE_EXTRA_RRECOMMENDS:append = " \
 	linux-firmware-rk-cdndp \
 "
+
+FIRMWARE_COMPRESSION = "1"

--- a/layers/meta-balena-rockpro64/recipes-kernel/linux/linux-rockchip/0001-dts-rk3399-rockpro64-enable-rng.patch
+++ b/layers/meta-balena-rockpro64/recipes-kernel/linux/linux-rockchip/0001-dts-rk3399-rockpro64-enable-rng.patch
@@ -1,0 +1,25 @@
+From 1bdf50c472824a7cd586c4191818966d3a8394d7 Mon Sep 17 00:00:00 2001
+From: Alex Gonzalez <alexg@balena.io>
+Date: Tue, 13 Sep 2022 14:02:43 +0200
+Subject: [PATCH] dts: rk3399-rockpro64: enable rng
+
+Signed-off-by: Alex Gonzalez <alexg@balena.io>
+---
+ arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
+index 6e553ff47534..9af80abb5855 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rockpro64.dtsi
+@@ -246,6 +246,10 @@ &hdmi_sound {
+ 	status = "okay";
+ };
+ 
++&rng {
++	status = "okay";
++};
++
+ &gpu {
+ 	mali-supply = <&vdd_gpu>;
+ 	status = "okay";

--- a/layers/meta-balena-rockpro64/recipes-kernel/linux/linux-rockchip_%.bbappend
+++ b/layers/meta-balena-rockpro64/recipes-kernel/linux/linux-rockchip_%.bbappend
@@ -1,3 +1,5 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
 inherit kernel-balena
 
 KERNEL_IMAGETYPES:remove = "${ROCKCHIP_KERNEL_IMAGES}"
@@ -6,6 +8,8 @@ python () {
     # revert variable set in rockchip BSP
     d.setVar('KERNEL_IMAGETYPE_FOR_MAKE', d.getVar('KERNEL_IMAGETYPES'));
 }
+
+SRC_URI += "file://0001-dts-rk3399-rockpro64-enable-rng.patch"
 
 # we disable Rockchip wifi stack since we currently do not support the external wifi module (will revisit bt / wifi in case it's required by customers)
 # if we do need to support bt / wifi we would better use the backported brcmfmac driver like we did for the RockPi 4B


### PR DESCRIPTION
Changelog-entry: Enable RNG for rk3399-rockpro64
Signed-off-by: Alex Gonzalez <alexg@balena.io>