### PR TITLE
build_and_deploy: update to v0.0.12

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   release-on-tag:
-    uses: balena-os/github-workflows/.github/workflows/build_and_deploy.yml@v0.0.9
+    uses: balena-os/github-workflows/.github/workflows/build_and_deploy.yml@v0.0.12
     with:
       deployTo: "production"
     secrets: inherit


### PR DESCRIPTION
This update identifies test job names with the default prefix `test`
instead of a hardcoded `testbot-`.

Changelog-entry: Update build and deploy workflow to v0.0.12
Signed-off-by: Alex Gonzalez <alexg@balena.io>
