### PR TITLE
bblayers.conf.sample: add meta-perl

### DIFF
--- a/layers/meta-balena-rockpro64/conf/samples/bblayers.conf.sample
+++ b/layers/meta-balena-rockpro64/conf/samples/bblayers.conf.sample
@@ -16,5 +16,6 @@ BBLAYERS ?= " \
     ${TOPDIR}/../layers/meta-openembedded/meta-filesystems \
     ${TOPDIR}/../layers/meta-openembedded/meta-networking \
     ${TOPDIR}/../layers/meta-openembedded/meta-python \
+    ${TOPDIR}/../layers/meta-openembedded/meta-perl \
     ${TOPDIR}/../layers/meta-rockchip \
     "


### PR DESCRIPTION
Perl is required for building efitools used for
EFI boot entry configuration and secure boot,

Changelog-entry: add meta-perl to bblayers.conf
Signed-off-by: Alex Gonzalez <alexg@balena.io>
